### PR TITLE
Fix README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,14 @@ var ram = require('random-access-memory')
 
 var hyper = hyperdb(ram, { valueEncoding: 'json' })
 var db = P2P(hyper)
-db.install('osm', new Osm(db))
+db.install('osm', new Osm(hyper))
 
 var node = {
   type: 'node',
   lat: '-12.7',
   lon: '1.3',
-  tags: { feature: 'water fountain' }
+  tags: { feature: 'water fountain' },
+  changeset: 'abcdef'
 }
 
 db.osm.create(node, function (err, id) {
@@ -77,4 +78,3 @@ $ npm install p2p-db-osm
 ## License
 
 ISC
-


### PR DESCRIPTION
The example in `master` recursively nests the `db` under itself
indefinitely. I'm not sure if this is the intended way to fix
this. Please let me know if I'm incorrect.

Additionally, I've added a `changeset` property to conform to the
requirements in the `checkElement` module.